### PR TITLE
Prevent plugin from recognizing ANY dropper gui to be a returnitems gui

### DIFF
--- a/src/main/java/com/mk7a/soulbind/itemreturn/ItemReturnCommand.java
+++ b/src/main/java/com/mk7a/soulbind/itemreturn/ItemReturnCommand.java
@@ -49,7 +49,7 @@ public class ItemReturnCommand implements CommandExecutor {
             return true;
         }
 
-
+        //Use our ItemReturnGUIHolder for identifying whether a gui belongs to us or not
         Inventory getItemsGUI = plugin.getServer().createInventory(new ItemReturnGUIHolder(), RETURN_INV_TYPE, ItemReturnModule.INV_TITLE);
 
         ArrayList<ItemStack> foundItemsList = foundItems.get(uuid);

--- a/src/main/java/com/mk7a/soulbind/itemreturn/ItemReturnCommand.java
+++ b/src/main/java/com/mk7a/soulbind/itemreturn/ItemReturnCommand.java
@@ -50,7 +50,7 @@ public class ItemReturnCommand implements CommandExecutor {
         }
 
 
-        Inventory getItemsGUI = plugin.getServer().createInventory(null, RETURN_INV_TYPE, ItemReturnModule.INV_TITLE);
+        Inventory getItemsGUI = plugin.getServer().createInventory(new ItemReturnGUIHolder(), RETURN_INV_TYPE, ItemReturnModule.INV_TITLE);
 
         ArrayList<ItemStack> foundItemsList = foundItems.get(uuid);
 

--- a/src/main/java/com/mk7a/soulbind/itemreturn/ItemReturnGUIHolder.java
+++ b/src/main/java/com/mk7a/soulbind/itemreturn/ItemReturnGUIHolder.java
@@ -1,0 +1,23 @@
+package com.mk7a.soulbind.itemreturn;
+
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+/**
+ * This custom InventoryHolder is used to identify whether a gui of type RETURN_INV_TYPE 
+ * in {@link ItemReturnCommand} belongs to the ItemReturnModule
+ * @author LOOHP
+ *
+ */
+public class ItemReturnGUIHolder implements InventoryHolder {
+	
+	protected ItemReturnGUIHolder() {
+		
+	}
+
+	@Override
+	public Inventory getInventory() {
+		return null;
+	}
+
+}

--- a/src/main/java/com/mk7a/soulbind/itemreturn/ItemReturnListener.java
+++ b/src/main/java/com/mk7a/soulbind/itemreturn/ItemReturnListener.java
@@ -126,7 +126,8 @@ public class ItemReturnListener implements Listener {
 
     @EventHandler
     public void invClickGUI(InventoryCloseEvent event) {
-        if (event.getInventory().getHolder() == null && event.getInventory().getType() == InventoryType.DROPPER) {
+    	//Check the instance of the InventoryHolder to make sure it is not a dropper gui from anther plugin
+        if (event.getInventory().getHolder() != null && event.getInventory().getHolder() instanceof ItemReturnGUIHolder && event.getInventory().getType() == InventoryType.DROPPER) {
             for (ItemStack item : event.getInventory().getContents()) {
                 if (item != null) {
                     event.getPlayer().getWorld().dropItemNaturally(event.getPlayer().getLocation(), item);


### PR DESCRIPTION
This PR address the issue where any dropper GUIs are seen as returnitem GUIs, which cause item duplication when a player closes a dropper GUI from other plugins.

The current implementation checks whether a dropper GUI has a null InventoryHolder, this is not safe as other plugins could be doing that as well. In this PR, we will check for an instance of our own InventoryHolder instead.

Fixes LOOHP/InteractiveChat#48